### PR TITLE
Add nodelet as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,32 @@
-# Generic MoveIt Travis Continuous Integration Configuration File
-# Works with all MoveIt! repositories/branches
-# Author: Dave Coleman, Jonathan Bohren
-language:
-  - cpp
-  - python
-python:
-  - "2.7"
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+language: generic 
 compiler:
   - gcc
 notifications:
   email:
+    on_success: always
+    on_failure: always
     recipients:
-    #  - davetcoleman@gmail.com
-    on_success: change #[always|never|change] # default: change
-    on_failure: change #[always|never|change] # default: always
-before_install: # Use this to prepare the system to install prerequisites or dependencies
-  # Define some config vars
-  - export ROS_DISTRO=hydro
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
-  # MongoDB hack - I don't fully understand this but its for moveit_warehouse
-  - sudo apt-get remove -y mongodb mongodb-10gen
-  - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" # default actions
-  # Setup rosdep
-  - sudo rosdep init
-  - rosdep update
-install: # Use this to install any prerequisites or dependencies necessary to run your build
-  # Create workspace
-  - mkdir -p ~/ros/ws_moveit/src
-  - cd ~/ros/ws_moveit/src
-  - wstool init .
-  # Download non-debian stuff
-  - wstool merge https://raw.github.com/ros-planning/moveit_docs/hydro-devel/moveit.rosinstall
-  - wstool update
-  # Delete the moveit.rosinstall version of this repo and use the one of the branch we are testing
-  - rm -rf $REPOSITORY_NAME
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-  - cd ../
-  # Install dependencies for source repos
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2
-
+      - 130s@2000.jukuin.keio.ac.jp
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#matrix:
+#  allow_failures:
+#    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - env: USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - env: USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/benchmarks/CHANGELOG.rst
+++ b/benchmarks/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_benchmarks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Adding tf dep fixes
 * Contributors: Dave Coleman, Mr-Yellow

--- a/benchmarks/CHANGELOG.rst
+++ b/benchmarks/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package moveit_ros_benchmarks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Adding tf dep fixes
+* Contributors: Dave Coleman, Mr-Yellow
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/benchmarks/package.xml
+++ b/benchmarks/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_benchmarks</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>MoveIt tools for benchmarking</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/benchmarks_gui/CHANGELOG.rst
+++ b/benchmarks_gui/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_benchmarks_gui
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Contributors: Dave Coleman
 

--- a/benchmarks_gui/CHANGELOG.rst
+++ b/benchmarks_gui/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package moveit_ros_benchmarks_gui
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Contributors: Dave Coleman
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/benchmarks_gui/package.xml
+++ b/benchmarks_gui/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_benchmarks_gui</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>MoveIt GUI tools for benchmarking</description>
 
   <author email="mprats@willowgarage.com">Mario Prats</author>

--- a/manipulation/CHANGELOG.rst
+++ b/manipulation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package moveit_ros_manipulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Contributors: Dave Coleman
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/manipulation/CHANGELOG.rst
+++ b/manipulation/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_manipulation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Contributors: Dave Coleman
 

--- a/manipulation/package.xml
+++ b/manipulation/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_manipulation</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt used for manipulation</description>
 
   <author email="isucan@gmail.com">Ioan Sucan</author>

--- a/move_group/CHANGELOG.rst
+++ b/move_group/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package moveit_ros_move_group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Fixed bug(?) in move_group::MoveGroupKinematicsService::computeIK link name selection.
+* Contributors: Dave Coleman, Mihai Pomarlan
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/move_group/CHANGELOG.rst
+++ b/move_group/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_move_group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Fixed bug(?) in move_group::MoveGroupKinematicsService::computeIK link name selection.
 * Contributors: Dave Coleman, Mihai Pomarlan

--- a/move_group/package.xml
+++ b/move_group/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_move_group</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>The move_group node for MoveIt</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/moveit_ros/CHANGELOG.rst
+++ b/moveit_ros/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package moveit_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Contributors: Dave Coleman
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/moveit_ros/CHANGELOG.rst
+++ b/moveit_ros/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Contributors: Dave Coleman
 

--- a/moveit_ros/package.xml
+++ b/moveit_ros/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt that use ROS</description>
   <author email="isucan@gmail.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/perception/CHANGELOG.rst
+++ b/perception/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package moveit_ros_perception
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* Added missing dependency on moveit_msgs package
+* Contributors: Andriy Petlovanyy, Dave Coleman, dg
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/perception/CHANGELOG.rst
+++ b/perception/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_perception
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * Added missing dependency on moveit_msgs package
 * Contributors: Andriy Petlovanyy, Dave Coleman, dg

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_perception</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt connecting to perception</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -26,6 +26,7 @@
   <build_depend>message_filters</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>opengl</build_depend>
   <build_depend>pluginlib</build_depend>
@@ -43,6 +44,7 @@
   <run_depend>message_filters</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_msgs</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>opengl</run_depend>
   <run_depend>pluginlib</run_depend>

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -18,40 +18,40 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>glut</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>libglew-dev</build_depend>
+  <build_depend>message_filters</build_depend>
   <build_depend>moveit_core</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>moveit_msgs</build_depend>
+  <build_depend>octomap</build_depend>
+  <build_depend>opengl</build_depend>
+  <build_depend>pluginlib</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>urdf</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>octomap</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>glut</build_depend>
-  <build_depend>libglew-dev</build_depend>
-  <build_depend>opengl</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>moveit_msgs</build_depend>
+  <build_depend>urdf</build_depend>
 
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>glut</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>libglew-dev</run_depend>
+  <run_depend>message_filters</run_depend>
   <run_depend>moveit_core</run_depend>
-  <run_depend>roscpp</run_depend>
+  <run_depend>moveit_msgs</run_depend>
+  <run_depend>octomap</run_depend>
+  <run_depend>opengl</run_depend>
+  <run_depend>pluginlib</run_depend>
   <run_depend>rosconsole</run_depend>
-  <run_depend>urdf</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf_conversions</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>octomap</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>glut</run_depend>
-  <run_depend>libglew-dev</run_depend>
-  <run_depend>opengl</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>moveit_msgs</run_depend>
+  <run_depend>urdf</run_depend>
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>

--- a/perception/point_containment_filter/src/shape_mask.cpp
+++ b/perception/point_containment_filter/src/shape_mask.cpp
@@ -148,7 +148,8 @@ void point_containment_filter::ShapeMask::maskContainment(const sensor_msgs::Poi
     sensor_msgs::PointCloud2ConstIterator<float> iter_z(data_in, "z");
 
     // Cloud iterators are not incremented in the for loop, because of the pragma
-#pragma omp parallel for schedule(dynamic)
+// Comment out below parallelization as it can result in very high CPU consumption    
+//#pragma omp parallel for schedule(dynamic)
     for (int i = 0 ; i < (int)np ; ++i)
     {
       Eigen::Vector3d pt = Eigen::Vector3d(*(iter_x+i), *(iter_y+i), *(iter_z+i));

--- a/planning/CHANGELOG.rst
+++ b/planning/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package moveit_ros_planning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* fixed segfault on shutdown
+  use of pluginlib's createUnmanagedInstance() is strongly discouraged:
+  http://wiki.ros.org/class_loader#Understanding_Loading_and_Unloading
+  here, the kinematics plugin libs were unloaded before destruction of corresponding pointers
+* Deprecate shape_tools
+* CurrentStateMonitor no longer requires hearing mimic joint state values.
+* Fix crash due to robot state not getting updated (moveit_ros #559)
+* Contributors: Dave Coleman, Dave Hershberger, Robert Haschke, kohlbrecher
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/planning/CHANGELOG.rst
+++ b/planning/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_planning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * fixed segfault on shutdown
   use of pluginlib's createUnmanagedInstance() is strongly discouraged:

--- a/planning/package.xml
+++ b/planning/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package>
   <name>moveit_ros_planning</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Planning components of MoveIt that use ROS</description>
   <author email="isucan@google.com">Ioan Sucan</author>
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>

--- a/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -157,7 +157,7 @@ public:
     if (result && res.trajectory_)
     {
       ROS_DEBUG("Running '%s'", getDescription().c_str());
-      if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor))
+      if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor, req.max_acceleration_scaling_factor))
         ROS_WARN("Time parametrization for the solution path failed.");
     }
 

--- a/planning_interface/CHANGELOG.rst
+++ b/planning_interface/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_planning_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * new method MoveGroup::getDefaultPlannerId(const std::string &group)
   ... to retrieve default planner config from param server

--- a/planning_interface/CHANGELOG.rst
+++ b/planning_interface/CHANGELOG.rst
@@ -2,6 +2,23 @@
 Changelog for package moveit_ros_planning_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* new method MoveGroup::getDefaultPlannerId(const std::string &group)
+  ... to retrieve default planner config from param server
+  moved corresponding code from rviz plugin to MoveGroup interface
+  to facilitate re-use
+* adding set_num_planning_attempts to python interface
+* Added python wrapper for setMaxVelocityScalingFactor
+* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
+* adding set_num_planning_attempts to python interface
+* Added python wrapper for MoveGroup.asyncExecute()
+* Add retime_trajectory to moveit python wrapper
+* add getHandle to move_group_interface
+* Updated documentation on move() to inform the user that an asynchronus spinner is required. Commonly new users don't do this and move() blocks permanently
+* Contributors: Dave Coleman, Dave Hershberger, Kei Okada, Michael Stevens, Robert Haschke, Sachin Chitta, Scott, Yoan Mollard, dg, ferherranz
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -166,7 +166,18 @@ public:
       (imporantly, this includes it being set to 0.0), the factor is set to a
       default value of 1.0 internally (i.e. maximum joint velocity) */
   void setMaxVelocityScalingFactor(double max_velocity_scaling_factor);
+<<<<<<< HEAD
 
+=======
+  
+  /** \brief Set a scaling factor for optionally reducing the maximum joint acceleration.
+      Allowed values are in (0,1]. The maximum joint acceleration specified
+      in the robot model is multiplied by the factor. If outside valid range
+      (imporantly, this includes it being set to 0.0), the factor is set to a
+      default value of 1.0 internally (i.e. maximum joint acceleration) */  
+  void setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor);
+  
+>>>>>>> Adding acceleration scaling factor
   /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;
 

--- a/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
+++ b/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group.h
@@ -166,18 +166,14 @@ public:
       (imporantly, this includes it being set to 0.0), the factor is set to a
       default value of 1.0 internally (i.e. maximum joint velocity) */
   void setMaxVelocityScalingFactor(double max_velocity_scaling_factor);
-<<<<<<< HEAD
 
-=======
-  
   /** \brief Set a scaling factor for optionally reducing the maximum joint acceleration.
       Allowed values are in (0,1]. The maximum joint acceleration specified
       in the robot model is multiplied by the factor. If outside valid range
       (imporantly, this includes it being set to 0.0), the factor is set to a
       default value of 1.0 internally (i.e. maximum joint acceleration) */  
   void setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor);
-  
->>>>>>> Adding acceleration scaling factor
+
   /** \brief Get the number of seconds set by setPlanningTime() */
   double getPlanningTime() const;
 

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -253,16 +253,12 @@ public:
   {
     max_velocity_scaling_factor_ = max_velocity_scaling_factor;
   }
-<<<<<<< HEAD
 
-=======
-  
   void setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor)
   {
     max_acceleration_scaling_factor_ = max_acceleration_scaling_factor;
   }
-  
->>>>>>> Adding acceleration scaling factor
+
   robot_state::RobotState& getJointStateTarget()
   {
     return *joint_state_target_;

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -183,9 +183,14 @@ public:
     }
 
     if (!action->isServerConnected())
-      throw std::runtime_error("Unable to connect to move_group action server within allotted time (2)");
+    {
+      std::string error = "Unable to connect to move_group action server '" + name + "' within allotted time (2)";
+      throw std::runtime_error(error);
+    }
     else
+    {
       ROS_DEBUG("Connected to '%s'", name.c_str());
+    }
   }
 
   ~MoveGroupImpl()

--- a/planning_interface/move_group_interface/src/move_group.cpp
+++ b/planning_interface/move_group_interface/src/move_group.cpp
@@ -117,6 +117,7 @@ public:
     planning_time_ = 5.0;
     num_planning_attempts_ = 1;
     max_velocity_scaling_factor_ = 1.0;
+    max_acceleration_scaling_factor_ = 1.0;
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())
@@ -252,7 +253,16 @@ public:
   {
     max_velocity_scaling_factor_ = max_velocity_scaling_factor;
   }
+<<<<<<< HEAD
 
+=======
+  
+  void setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor)
+  {
+    max_acceleration_scaling_factor_ = max_acceleration_scaling_factor;
+  }
+  
+>>>>>>> Adding acceleration scaling factor
   robot_state::RobotState& getJointStateTarget()
   {
     return *joint_state_target_;
@@ -838,6 +848,7 @@ public:
     goal.request.group_name = opt_.group_name_;
     goal.request.num_planning_attempts = num_planning_attempts_;
     goal.request.max_velocity_scaling_factor = max_velocity_scaling_factor_;
+    goal.request.max_acceleration_scaling_factor = max_acceleration_scaling_factor_;
     goal.request.allowed_planning_time = planning_time_;
     goal.request.planner_id = planner_id_;
     goal.request.workspace_parameters = workspace_parameters_;
@@ -1024,6 +1035,7 @@ private:
   std::string planner_id_;
   unsigned int num_planning_attempts_;
   double max_velocity_scaling_factor_;
+  double max_acceleration_scaling_factor_;
   double goal_joint_tolerance_;
   double goal_position_tolerance_;
   double goal_orientation_tolerance_;
@@ -1116,6 +1128,10 @@ void moveit::planning_interface::MoveGroup::setMaxVelocityScalingFactor(double m
   impl_->setMaxVelocityScalingFactor(max_velocity_scaling_factor);
 }
 
+void moveit::planning_interface::MoveGroup::setMaxAccelerationScalingFactor(double max_acceleration_scaling_factor)
+{
+  impl_->setMaxAccelerationScalingFactor(max_acceleration_scaling_factor);
+}
 
 moveit::planning_interface::MoveItErrorCode moveit::planning_interface::MoveGroup::asyncMove()
 {

--- a/planning_interface/package.xml
+++ b/planning_interface/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_planning_interface</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt that offer simpler interfaces to planning and execution</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/robot_interaction/CHANGELOG.rst
+++ b/robot_interaction/CHANGELOG.rst
@@ -2,6 +2,33 @@
 Changelog for package moveit_ros_robot_interaction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* further adapted marker size computation
+  - drop largest extension dimension (-> use cross-section size of elongated link)
+  - for an end-effector group, consider the sizes of individual links
+  instead of the overall size of all links (which becomes huge very fast)
+  - enlarge marker size by factor of 1.5 when there is only a single eef marker
+* reworked computeLinkMarkerSize()
+  compute size such that the marker sphere will cover
+  - a spherical link geometry -> AABB.maxCoeff
+  - a cubical link geometry -> AABB.norm
+  -> use average of both values
+  Virtual links (without any shape) will have a size of AABB of zero dims.
+  In this case use the dimensions of the closest parent link instead.
+* improved computation of interactive marker size
+  - use parent_link if group == parent_group
+  - scale smaller than 5cm is clipped to 5cm instead of using default
+  - clarified size computation, using diameter of AABB
+* fixing error caused by BOOST_STATIC_ASSERT
+* Fixed compile error caused by BOOST_STATIC_ASSERT in kinematic_options.cpp
+  Added kinematics::DiscretizationMethods::DiscretizationMethod to QO_FIELDS in kinematic_options.cpp.
+  At pull request #581, type of discretization_method was set to int. Changed it to proper type.
+* reinstated changes related to the updates in the  moveit_core::KinematicsBase interface
+* adds the 'returns_approximate_solution' entry so that it is compatible with the changes in kinematics::KinematicsBase class in the moveit_core repo
+* Contributors: Daichi Yoshikawa, Dave Coleman, Robert Haschke, Sachin Chitta, jrgnicho
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/robot_interaction/CHANGELOG.rst
+++ b/robot_interaction/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_robot_interaction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * further adapted marker size computation
   - drop largest extension dimension (-> use cross-section size of elongated link)

--- a/robot_interaction/package.xml
+++ b/robot_interaction/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_robot_interaction</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt that offer interaction via interactive markers</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/visualization/CHANGELOG.rst
+++ b/visualization/CHANGELOG.rst
@@ -2,6 +2,64 @@
 Changelog for package moveit_ros_visualization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* new method MoveGroup::getDefaultPlannerId(const std::string &group)
+  ... to retrieve default planner config from param server
+  moved corresponding code from rviz plugin to MoveGroup interface
+  to facilitate re-use
+* correctly initialize scene robot's parameters after initialization
+  - loaded parameters were ignored
+  - changed default alpha value to 1 to maintain previous behaviour
+* load default_planner_config from default location
+  instead of loading from `/<ns>/default_planner_config`, use
+  `/<ns>/move_group/<group>/default_planner_config`, which is the default
+  location for `planner_configs` too
+* Merge pull request #610 : correctly update all markers after robot motion
+* fixing conflicts, renaming variable
+* Merge pull request #612 from ubi-agni/interrupt-traj-vis
+  interrupt trajectory visualization on arrival of new display trajectory
+* fixup! cleanup TrajectoryVisualization::update
+  only enter visualization loop when displaying_trajectory_message is defined
+* added missing initialization
+* correctly setAlpha for new trail
+* fixed race condition for trajectory-display interruption
+  - TrajectoryVisualization::update() switches to new trajectory
+  automatically when it has finished displaying the old one
+  - TrajectoryVisualization::interruptCurrentDisplay() might interrupt
+  this newly started trajectory
+  consequences:
+  - protect switching of trajectory with mutex
+  - interrupt only if trajectory display progressed past first waypoint
+  - removed obsolete signal timeToShowNewTrail:
+  update() automatically switches and updates trail in sync
+* cleanup TrajectoryVisualization::update
+  simplified code to switch to new trajectory / start over animation in loop mode
+* new GUI property to allow immediate interruption of displayed trajectory
+* immediately show trajectory after planning (interrupting current display)
+* fix segfault when disabling and re-enabling TrajectoryVisualization
+  animating_path was still true causing update() to access
+  displaying_trajectory_message, which was reset onDisable().
+* update pose of all markers when any marker moved
+  Having several end-effector markers attached to a group (e.g. a multi-
+  fingered hand having an end-effector per fingertip and an end-effector
+  for the hand base), all markers need to update their pose on any motion
+  of any marker. In the example: if the hand base is moved, the fingertip
+  markers should be moved too.
+* use move_group/default_workspace_bounds as a fallback for workspace bounds
+* code style cleanup
+* fixed tab order of rviz plugin widgets
+* load / save rviz' workspace config
+* saves robot name to db from moveit. also robot name accessible through robot interface python wrapper
+* Added install rule to install moveit_joy.py.
+* motion_planning_frame_planning: use /default_planner_config parma to specify default planning algorithm
+* Avoid adding a slash if getMoveGroupNS() is empty.
+  If the getMoveGroupNS() returns an empty string, ros::names::append() inserts a slash in front of 'right', which changes it to a global name.
+  Checking getMoveGroupNS() before calling append removes the issue.
+  append() behaviour will not be changed in ros/ros_comm.
+* Contributors: Dave Coleman, Jochen Welle, Kei Okada, Robert Haschke, Sachin Chitta, TheDash, dg
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/visualization/CHANGELOG.rst
+++ b/visualization/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_visualization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * new method MoveGroup::getDefaultPlannerId(const std::string &group)
   ... to retrieve default planner config from param server

--- a/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
+++ b/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_planning.cpp
@@ -280,7 +280,8 @@ void MotionPlanningFrame::constructPlanningRequest(moveit_msgs::MotionPlanReques
   mreq.group_name = planning_display_->getCurrentPlanningGroup();
   mreq.num_planning_attempts = ui_->planning_attempts->value();
   mreq.allowed_planning_time = ui_->planning_time->value();
-  mreq.max_velocity_scaling_factor = ui_->exec_time_factor->value();
+  mreq.max_velocity_scaling_factor = ui_->velocity_scaling_factor->value();
+  mreq.max_acceleration_scaling_factor = ui_->acceleration_scaling_factor->value();
   robot_state::robotStateToRobotStateMsg(*planning_display_->getQueryStartState(), mreq.start_state);
   mreq.workspace_parameters.min_corner.x = ui_->wcenter_x->value() - ui_->wsize_x->value() / 2.0;
   mreq.workspace_parameters.min_corner.y = ui_->wcenter_y->value() - ui_->wsize_y->value() / 2.0;
@@ -341,7 +342,8 @@ void MotionPlanningFrame::configureForPlanning()
   move_group_->setJointValueTarget(*planning_display_->getQueryGoalState());
   move_group_->setPlanningTime(ui_->planning_time->value());
   move_group_->setNumPlanningAttempts(ui_->planning_attempts->value());
-  move_group_->setMaxVelocityScalingFactor(ui_->exec_time_factor->value());
+  move_group_->setMaxVelocityScalingFactor(ui_->velocity_scaling_factor->value());
+  move_group_->setMaxAccelerationScalingFactor(ui_->acceleration_scaling_factor->value());
   configureWorkspace();
 }
 

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -643,9 +643,9 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
+           <layout class="QHBoxLayout" name="horizontalLayout_20">
             <item>
-             <widget class="QLabel" name="label_11">
+             <widget class="QLabel" name="label_20">
               <property name="text">
                <string>Acceleration Scaling:</string>
               </property>
@@ -1613,7 +1613,8 @@
   <tabstop>wsize_z</tabstop>
   <tabstop>planning_time</tabstop>
   <tabstop>planning_attempts</tabstop>
-  <tabstop>exec_time_factor</tabstop>
+  <tabstop>velocity_scaling_factor</tabstop>
+  <tabstop>acceleration_scaling_factor</tabstop>
   <tabstop>allow_replanning</tabstop>
   <tabstop>allow_looking</tabstop>
   <tabstop>allow_external_program</tabstop>

--- a/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
+++ b/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>702</width>
-    <height>395</height>
+    <height>413</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -628,7 +628,31 @@
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="exec_time_factor">
+             <widget class="QDoubleSpinBox" name="velocity_scaling_factor">
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Acceleration Scaling:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="acceleration_scaling_factor">
               <property name="maximum">
                <double>1.000000000000000</double>
               </property>

--- a/visualization/package.xml
+++ b/visualization/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_visualization</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt that offer visualization</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>

--- a/warehouse/CHANGELOG.rst
+++ b/warehouse/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package moveit_ros_warehouse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Removed trailing whitespace from entire repository
+* changed to global node handle so warehouse connection params work correctly
+* removed extraneous includes
+* added delete and rename
+* now takes port + host from param server
+* removed defunct code
+* checks db connection is good
+* services advertised
+* Contributors: Dave Coleman, dg
+
 0.6.5 (2015-01-24)
 ------------------
 * update maintainers

--- a/warehouse/CHANGELOG.rst
+++ b/warehouse/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package moveit_ros_warehouse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2016-01-30)
+------------------
 * Removed trailing whitespace from entire repository
 * changed to global node handle so warehouse connection params work correctly
 * removed extraneous includes

--- a/warehouse/package.xml
+++ b/warehouse/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_ros_warehouse</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>Components of MoveIt connecting to MongoDB</description>
 
   <author email="isucan@google.com">Ioan Sucan</author>


### PR DESCRIPTION
`nodelet` is used in `mesh_filter` ([example](https://github.com/ros-planning/moveit_ros/blob/483518f775d03666c611377d5270ffbf66427dac/perception/mesh_filter/src/depth_self_filter_nodelet.cpp#L37)).
