### PR TITLE
[Retry] Add nodelet as a dependency 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,32 @@
-# Generic MoveIt Travis Continuous Integration Configuration File
-# Works with all MoveIt! repositories/branches
-# Author: Dave Coleman, Jonathan Bohren
-language:
-  - cpp
-  - python
-python:
-  - "2.7"
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+language: generic 
 compiler:
   - gcc
 notifications:
   email:
+    on_success: always
+    on_failure: always
     recipients:
-    #  - davetcoleman@gmail.com
-    on_success: change #[always|never|change] # default: change
-    on_failure: change #[always|never|change] # default: always
-before_install: # Use this to prepare the system to install prerequisites or dependencies
-  # Define some config vars
-  - export ROS_DISTRO=hydro
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
-  # MongoDB hack - I don't fully understand this but its for moveit_warehouse
-  - sudo apt-get remove -y mongodb mongodb-10gen
-  - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" # default actions
-  # Setup rosdep
-  - sudo rosdep init
-  - rosdep update
-install: # Use this to install any prerequisites or dependencies necessary to run your build
-  # Create workspace
-  - mkdir -p ~/ros/ws_moveit/src
-  - cd ~/ros/ws_moveit/src
-  - wstool init .
-  # Download non-debian stuff
-  - wstool merge https://raw.github.com/ros-planning/moveit_docs/hydro-devel/moveit.rosinstall
-  - wstool update
-  # Delete the moveit.rosinstall version of this repo and use the one of the branch we are testing
-  - rm -rf $REPOSITORY_NAME
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-  - cd ../
-  # Install dependencies for source repos
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2
-
+      - 130s@2000.jukuin.keio.ac.jp
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#matrix:
+#  allow_failures:
+#    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+#    - env: USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#    - env: USE_DEB=false  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - source .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -26,6 +26,7 @@
   <build_depend>message_filters</build_depend>
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>opengl</build_depend>
   <build_depend>pluginlib</build_depend>
@@ -43,6 +44,7 @@
   <run_depend>message_filters</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_msgs</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>opengl</run_depend>
   <run_depend>pluginlib</run_depend>

--- a/perception/package.xml
+++ b/perception/package.xml
@@ -18,40 +18,40 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>glut</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>libglew-dev</build_depend>
+  <build_depend>message_filters</build_depend>
   <build_depend>moveit_core</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>moveit_msgs</build_depend>
+  <build_depend>octomap</build_depend>
+  <build_depend>opengl</build_depend>
+  <build_depend>pluginlib</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>urdf</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>octomap</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>glut</build_depend>
-  <build_depend>libglew-dev</build_depend>
-  <build_depend>opengl</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>moveit_msgs</build_depend>
+  <build_depend>urdf</build_depend>
 
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>glut</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>libglew-dev</run_depend>
+  <run_depend>message_filters</run_depend>
   <run_depend>moveit_core</run_depend>
-  <run_depend>roscpp</run_depend>
+  <run_depend>moveit_msgs</run_depend>
+  <run_depend>octomap</run_depend>
+  <run_depend>opengl</run_depend>
+  <run_depend>pluginlib</run_depend>
   <run_depend>rosconsole</run_depend>
-  <run_depend>urdf</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf_conversions</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>octomap</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>glut</run_depend>
-  <run_depend>libglew-dev</run_depend>
-  <run_depend>opengl</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>moveit_msgs</run_depend>
+  <run_depend>urdf</run_depend>
 
   <export>
     <moveit_ros_perception plugin="${prefix}/pointcloud_octomap_updater_plugin_description.xml"/>


### PR DESCRIPTION
Re-opening #1, since it didn't go well for some reason.

`nodelet` is used in `mesh_filter` ([example](https://github.com/ros-planning/moveit_ros/blob/483518f775d03666c611377d5270ffbf66427dac/perception/mesh_filter/src/depth_self_filter_nodelet.cpp#L37)).
